### PR TITLE
Fix code accessing id of undefined

### DIFF
--- a/src/ext.ts
+++ b/src/ext.ts
@@ -28,7 +28,7 @@ export async function activate(context: flashpoint.ExtensionContext) {
   flashpoint.services.onServiceRemove((process) => {
     if (process.id.startsWith('game.') && process.id.length > 5) {
       let closedId = process.id.substr(5);
-      if (closedId === curGame.id) {
+      if (curGame !== undefined && closedId === curGame.id) {
         curActivity = createActivity();
         curGame = undefined;
       }


### PR DESCRIPTION
Hi,

There was a small issue where starting an extreme game with "Display Extreme Games" disabled would throw an exception in the History tab when closing it, this was due of trying to access the id of "curGame" who was undefined
I made a small PR to fix this